### PR TITLE
Update bytes_modbus_uplink_converter.py

### DIFF
--- a/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
+++ b/thingsboard_gateway/connectors/modbus/bytes_modbus_uplink_converter.py
@@ -123,6 +123,11 @@ class BytesModbusUplinkConverter(ModbusConverter):
 
         elif lower_type == "bytes":
             decoded = decoder_functions[type_](size=objects_count * 2)
+            
+        elif lower_type in ['bit','bits']:
+            decoded_lastbyte= decoder_functions[type_]()
+            decoded= decoder_functions[type_]()
+            decoded+=decoded_lastbyte
 
         elif decoder_functions.get(lower_type) is not None:
             decoded = decoder_functions[lower_type]()


### PR DESCRIPTION
Added the "bits" decoding including both 2 bytes from the register instead of one. Could not use decoded= decoder_functions[type_](size=objects_count * 2) so I used a little trick  to get the bits in the right order (decoded+=)